### PR TITLE
Add unit tests for API components

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import sys
+import types
+from pathlib import Path
+
+module = types.ModuleType("mistralai")
+module.Mistral = object
+sys.modules.setdefault("mistralai", module)
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -1,0 +1,43 @@
+import os
+os.environ["SECRET_KEY"]="test"
+from datetime import timedelta
+
+import pytest
+
+from api.v1.security.api_auth import APIAuth
+
+
+class DummyMongo:
+    def __init__(self):
+        self.user = {"_id": "u", "username": "me", "hashed_password": ""}
+
+    async def find_one(self, collection, query, projection=None):
+        if collection == "users" and query.get("username") == "me":
+            return self.user
+        if collection == "users" and query.get("_id") == "u":
+            return self.user
+        return None
+
+    async def insert_one(self, collection, doc):
+        return True
+
+    def serialize(self, doc):
+        return doc
+
+
+@pytest.mark.asyncio
+async def test_password_hash_and_verify():
+    auth = APIAuth()
+    pw = "secret"
+    hashed = auth.hash_password(pw)
+    assert auth.verify_password(pw, hashed)
+
+
+@pytest.mark.asyncio
+async def test_token_roundtrip():
+    os.environ["SECRET_KEY"] = "s"
+    auth = APIAuth()
+    auth.set_mongo_client(DummyMongo())
+    token = auth.create_access_token({"sub": "me"}, timedelta(minutes=1))
+    user = await auth.verify_token(token)
+    assert user["username"] == "me"

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -1,0 +1,71 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from api.classes.text_generation import TextGeneration
+from api.classes.embeddings import Embeddings
+
+
+class DummyProvider:
+    def __init__(self):
+        self.complete = AsyncMock(return_value="result")
+        self.generate_embeddings = AsyncMock(
+            return_value={"data": [{"object": "embedding", "embedding": [0.1, 0.2]}]}
+        )
+        self.check_model = AsyncMock()
+        self.list_models = AsyncMock(return_value=["model1"])
+
+    async def stream(self, *args, **kwargs):
+        yield "chunk1", None
+        yield "chunk2", "stop"
+
+
+@pytest.mark.asyncio
+async def test_text_generation_complete():
+    provider = DummyProvider()
+    tg = TextGeneration(provider, SimpleNamespace(format_response=lambda r, j: {"formatted": r, "job_id": j}))
+    result = await tg.complete("model", [], 0.7, 10, 0.9, "job")
+    assert result == {"formatted": "result", "job_id": "job"}
+    provider.complete.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_text_generation_stream():
+    provider = DummyProvider()
+    tg = TextGeneration(provider, SimpleNamespace())
+    chunks = []
+    async for c in tg.generate_stream_response("model", [], 0.7, 10, 0.9, "job"):
+        chunks.append(c)
+    assert chunks[-1]["finish_reason"] == "stop"
+
+
+@pytest.mark.asyncio
+async def test_embeddings_generate_embeddings_dict():
+    provider = DummyProvider()
+    embed = Embeddings(provider, SimpleNamespace(
+        embedding_to_points=lambda i, d: "points",
+        embedding_to_tuple=lambda i, d: ([0], [[0.1, 0.2]], [{}]),
+        format_embeddings=lambda i, d, j: {"job_id": j, "embeddings": d},
+    ))
+    data = await embed.generate_embeddings("model", ["a"], "job")
+    assert data["job_id"] == "job"
+    provider.generate_embeddings.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_embeddings_output_tuple():
+    provider = DummyProvider()
+    utils = SimpleNamespace(
+        embedding_to_points=lambda i, d: "points",
+        embedding_to_tuple=lambda i, d: ([0], [[0.1, 0.2]], [{}]),
+        format_embeddings=lambda i, d, j: {"job_id": j, "embeddings": d},
+    )
+    embed = Embeddings(provider, utils)
+    ids, vectors, payloads = await embed.generate_embeddings(
+        "model", ["a"], "job", output_format="tuple"
+    )
+    assert ids == [0]
+    assert vectors == [[0.1, 0.2]]
+    assert payloads == [{}]

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -1,0 +1,31 @@
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from api.databases.mongo_db_connector import MongoDBConnector
+from api.databases.qdrant_connector import QdrantConnector
+
+
+class DummyLogger:
+    def __getattr__(self, name):
+        return lambda *args, **kwargs: None
+
+
+def test_mongo_serialize():
+    connector = MongoDBConnector(DummyLogger())
+    doc = {"_id": connector.object_id("64b8a3000000000000000000"), "value": 1}
+    serialized = connector.serialize(doc)
+    assert isinstance(serialized["_id"], str)
+
+
+@pytest.mark.asyncio
+async def test_qdrant_create_collection():
+    with patch.dict(os.environ, {"QDRANT_API_KEY": "k", "QDRANT_URL": "u"}):
+        with patch("api.databases.qdrant_connector.AsyncQdrantClient") as client_cls:
+            client = MagicMock()
+            client.create_collection = AsyncMock(return_value=True)
+            client_cls.return_value = client
+            qc = QdrantConnector(DummyLogger())
+            await qc.create_collection("col")
+            client.create_collection.assert_awaited()

--- a/tests/test_rag_service.py
+++ b/tests/test_rag_service.py
@@ -1,0 +1,40 @@
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from api.v1.services.rag_service import RagService
+
+
+class DummyEmbeddings:
+    def __init__(self):
+        self.generate_embeddings = AsyncMock(return_value=([0], [[0.1, 0.2]], [{}]))
+
+
+@pytest.mark.asyncio
+async def test_encode_to_collection():
+    with patch.dict(os.environ, {"QDRANT_API_KEY": "k", "QDRANT_URL": "u"}):
+        qdrant = MagicMock()
+        qdrant.get_collection = AsyncMock(side_effect=[None, MagicMock(model_dump_json=lambda: "{}")])
+        qdrant.create_collection = AsyncMock(return_value=True)
+        qdrant.batch_upsert = AsyncMock()
+
+        mongo = MagicMock()
+        service = RagService(DummyEmbeddings(), qdrant, mongo)
+        res = await service.encode_to_collection("col", ["text"], "model")
+        qdrant.create_collection.assert_awaited()
+        qdrant.batch_upsert.assert_awaited()
+        assert res["collection_name"] == "col"
+
+
+@pytest.mark.asyncio
+async def test_retrieve_in_collection():
+    with patch.dict(os.environ, {"QDRANT_API_KEY": "k", "QDRANT_URL": "u"}):
+        qdrant = MagicMock()
+        qdrant.search_in_collection = AsyncMock(return_value=[{"payload": {}, "score": 0.9}])
+        embeddings = DummyEmbeddings()
+        service = RagService(embeddings, qdrant, MagicMock())
+        results = await service.retrieve_in_collection("col", "q", "model")
+        embeddings.generate_embeddings.assert_awaited()
+        qdrant.search_in_collection.assert_awaited_with(collection_name="col", query_vector=[0.1,0.2], limit=5)
+        assert results[0]["score"] == 0.9

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,23 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from api.v1.endpoints import health_check
+
+
+class DummyDB:
+    def __init__(self):
+        self.find_one = AsyncMock()
+        self.insert_one = AsyncMock()
+        self.get_client = lambda: MagicMock(close=lambda: None)
+
+
+@pytest.fixture(autouse=True)
+def startup_patch():
+    with patch("api.main.ensure_database_connection", AsyncMock(return_value=(DummyDB(), DummyDB()))):
+        yield
+
+
+@pytest.mark.asyncio
+async def test_health_endpoint(startup_patch):
+    result = await health_check()
+    assert result["status"] == "ok"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,38 @@
+import pytest
+
+from api.utils.inference import InferenceUtils, Message
+
+
+def test_format_messages():
+    history = [Message(role="user", content="hi"), Message(role="assistant", content="hello")]
+    result = InferenceUtils.format_messages("sys", "question", history)
+    assert result == [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+        {"role": "user", "content": "question"},
+    ]
+
+
+def test_format_response():
+    resp = InferenceUtils.format_response("answer", "job")
+    assert resp == {"result": "answer", "job_id": "job"}
+
+
+def test_embedding_helpers():
+    inputs = ["a", "b"]
+    data = [
+        {"object": "embedding", "embedding": [1.0, 0.0]},
+        {"object": "embedding", "embedding": [0.0, 1.0]},
+    ]
+    points = InferenceUtils.embedding_to_points(inputs, data)
+    assert points[0]["payload"]["source_text"] == "a"
+
+    ids, vectors, payloads = InferenceUtils.embedding_to_tuple(inputs, data)
+    assert ids == [0, 1]
+    assert vectors == [[1.0, 0.0], [0.0, 1.0]]
+    assert payloads[1]["source_text"] == "b"
+
+    formatted = InferenceUtils.format_embeddings(inputs, data, "job")
+    assert formatted["job_id"] == "job"
+    assert len(formatted["embeddings"]) == 2


### PR DESCRIPTION
## Summary
- add pytest suite covering utils, classes, connectors, auth, rag service and endpoints
- include helper `conftest.py` to set up paths and stub external libs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849726a10d0832da90b94be82e92b10